### PR TITLE
Migrations path set by env variable

### DIFF
--- a/src/elastic-migrate-utils.js
+++ b/src/elastic-migrate-utils.js
@@ -90,11 +90,10 @@ const getHostMigrations = async () => {
 };
 
 const getLocalMigrations = async () => {
-  const migrationsPath = process.env.ELASTIC_MIGRATE_MIGRATIONS_PATH  || './migrations'
-  const files = (await readdir(path.resolve(migrationsPath)))
+  const files = (await readdir(elasticMigrateMigrationsPath))
   return files.map(item => {
       const [filename, version, description] = /(\d*)\_(.*).js/gi.exec(item);
-      return {description, version, filepath: path.resolve(migrationsPath, filename)};
+      return {description, version, filepath: path.resolve(elasticMigrateMigrationsPath, filename)};
     })
     .sort((a, b) => a.version.localeCompare(b.version));
 };

--- a/src/elastic-migrate-utils.js
+++ b/src/elastic-migrate-utils.js
@@ -3,7 +3,7 @@ const path = require('path');
 const exec = util.promisify(require('child_process').exec);
 const readdir = util.promisify(require('fs').readdir);
 const elasticMigrateMigrationsIndexName = process.env.ELASTIC_MIGRATE_MIGRATIONS_INDEX_NAME || 'elastic_migrate_migrations';
-const elasticMigrateMigrationsPath = process.env.ELASTIC_MIGRATE_MIGRATIONS_PATH || path.resolve('./migrations');
+const elasticMigrateMigrationsPath = path.resolve(process.env.ELASTIC_MIGRATE_MIGRATIONS_PATH || './migrations');
 const {Client} = require('elasticsearch');
 const ConfigurationError = require("./configuration-error");
 const RuntimeError = require("./runtime-error");
@@ -90,10 +90,11 @@ const getHostMigrations = async () => {
 };
 
 const getLocalMigrations = async () => {
-  const files = (await readdir(path.resolve('./migrations')))
+  const migrationsPath = process.env.ELASTIC_MIGRATE_MIGRATIONS_PATH  || './migrations'
+  const files = (await readdir(path.resolve(migrationsPath)))
   return files.map(item => {
       const [filename, version, description] = /(\d*)\_(.*).js/gi.exec(item);
-      return {description, version, filepath: path.resolve('./migrations', filename)};
+      return {description, version, filepath: path.resolve(migrationsPath, filename)};
     })
     .sort((a, b) => a.version.localeCompare(b.version));
 };


### PR DESCRIPTION
In current version there is an option to set migrations path by env variable, but in function `getLocalMigrations` path is only set by default value `./migrations`. I fixed it by added const `elasticMigrateMigrationsPath` with env value if it set.